### PR TITLE
Added spawning of UGV and spawning based on file

### DIFF
--- a/cli/commands/install
+++ b/cli/commands/install
@@ -91,6 +91,11 @@ sudo apt-get update
 sudo apt-get install -y python3 python3-pip curl uidmap
 pip3 install click
 
+# Install YQ
+echo "Installing YQ (https://github.com/mikefarah/yq/#install) for yaml parsing"
+wget https://github.com/mikefarah/yq/releases/download/v4.24.5/yq_linux_arm64 -O /usr/bin/yq &&\
+    chmod +x /usr/bin/yq
+
 # Adding starling to bashrc
 for rcfile in "${RC_FILES[@]}"; do
     if [[ -f $rcfile ]]; then

--- a/cli/commands/simulator
+++ b/cli/commands/simulator
@@ -12,11 +12,12 @@ commands:
     start\t\tStarts gazebo iris with px4 and vehicle with specified number of vehicles
     stop\t\tStops all simulator instances
     restart\t\tRestarts the simulator
-    set\t\tSets the number of vehicles in the simulator
     load\t\tLoads local docker images into kind
 
 Arguments:
     --load\t\tAlso loads local docker images into kind, use with start
+    --simulator_kube_deployment_yaml <file>\tSet the default simulation container deployment file
+
 "
 }
 
@@ -25,6 +26,9 @@ if [ -z ${STARLING_COMMON_SOURCED+'check'} ]; then
     echo "Common not sourced, please run from starling cli"
     exit 1
 fi
+
+SIM_DEPLOYMENT_FILE="${STARLING_WORKDIR}/kubernetes/simulation/k8.gazebo-iris.amd64.yaml"
+SITL_DEPLOYMENT_FILE="${STARLING_WORKDIR}/kubernetes/simulation/k8.px4-sitl.daemonset.yaml"
 
 # Parse arguments
 while [[ $# -gt 0 ]]
@@ -52,8 +56,13 @@ do
             LOAD=1
             shift
             ;;
-        set)
-            NUM_VEHICLES=$2
+        --simulator_kube_deployment_yaml)
+            SIM_DEPLOYMENT_FILE=$2
+            shift
+            shift
+            ;;
+        --sitl_kube_deployment_yaml)
+            SITL_DEPLOYMENT_FILE=$2
             shift
             shift
             ;;
@@ -67,8 +76,8 @@ do
 done
 
 SIMULATOR_DEPLOYMENT_LIST=(
-    "${STARLING_WORKDIR}/kubernetes/simulation/k8.gazebo-iris.amd64.yaml"
-    "${STARLING_WORKDIR}/kubernetes/simulation/k8.px4-sitl.daemonset.yaml"
+    "${SIM_DEPLOYMENT_FILE}"
+    "${SITL_DEPLOYMENT_FILE}"
     "${STARLING_WORKDIR}/kubernetes/k8.mavros.daemonset.yaml"
 );
 
@@ -113,11 +122,4 @@ if [[ $START ]]; then
     for file in "${SIMULATOR_DEPLOYMENT_LIST[@]}"; do
         kubectl apply -f "$file"
     done
-fi
-
-
-if [[ $NUM_VEHICLES ]]; then
-    echo "Attempting to scale number of vehicles"
-    echo "(Note scaling down might require a restart)"
-    kubectl scale statefulsets starling-px4-sitl --replicas=$NUM_VEHICLES
 fi

--- a/cli/commands/start
+++ b/cli/commands/start
@@ -13,7 +13,9 @@ Usage:
     dashboard\t\tStarts kubernetes dashboard
 
 Options
-    --num_vehicles -n\t Maximum number of vehicles to start
+    --num_uavs -n\t Maximum number of uavs to start (1 by default)
+    --num_ugvs -n_ugv\t Maximum number of ground vehicles to start (0 by default)
+    --vehicle_config_yaml\t Yaml file dictating the vehicle setup. Accepting a list of 'vehicles', specifying 'type', 'x', 'y' and 'z'
 "
 }
 
@@ -33,8 +35,18 @@ do
             cli_help_install
             exit 1
             ;;
-        -n|--num_vehicles)
+        -n|--num_uavs)
             NUM_VEH=$2
+            shift
+            shift
+            ;;
+        -n_ugv|--num_ugvs)
+            NUM_UGV=$2
+            shift
+            shift
+            ;;
+        --vehicle_config_yaml)
+            VEHICLE_CONFIG_YAML=$2
             shift
             shift
             ;;
@@ -68,35 +80,109 @@ done
 # Both configurations are put in a temporary /tmp folder
 # These files are then mounted into the kind node containers
 if [[ $S_KIND ]]; then
-    ## Determine number of vehicles (default 1)
-    echo "Number of vehicles set to $NUM_VEH"
 
     controlplanenode="starling-cluster-control-plane"
     echo "Control plane node: $controlplanenode"
 
-    ## Write Vehicle Configuration files into tmp folder after creating tmp folder
-    ## These mirror the config files found on real vehicles
-    mkdir -p "${STARLING_TMP_DIR}"
-    for (( idx=0; idx<NUM_VEH; idx++ )); do
-        CONFPATH="${STARLING_TMP_DIR}/vehicle${idx}.config"
-        touch "$CONFPATH"
-        # PX4_INSTANCE is required otherwise vehicles all default to zero
-        # PX4_SIM_HOST is for SITL connecting to gazebo instance on the control plane node
-        # PX4_SIM_INIT_LOC_X is to ensure multiple vehicles do not spawn on top of each other
-        # VEHILCE_FCU_URL is set as mavros only autogenerates if config is not provided. We provide config, so we must recreate the URL
-        { echo "PX4_INSTANCE=${idx}";
-          echo "PX4_SIM_HOST=${controlplanenode}";
-          echo "PX4_SIM_INIT_LOC_X=$((idx))";
-          echo "VEHICLE_FCU_URL=udp://127.0.0.1:$((14830+idx))@/";
-          echo "VEHICLE_FIRMWARE=px4";
-          echo "VEHICLE_MAVLINK_SYSID=$((idx+1))";
-          echo "VEHICLE_NAME=vehicle_${idx}";} > "$CONFPATH"
-        touch "${STARLING_TMP_DIR}/px4fmu_vehicle${idx}"
-    done
+    if [[ ! $VEHICLE_CONFIG_YAML ]]; then
+        ## Write Vehicle Configuration files into tmp folder after creating tmp folder
+        ## These mirror the config files found on real vehicles
+
+        ## Determine number of vehicles (default 1)
+        echo "Number of UAVs set to $NUM_VEH"
+
+        mkdir -p "${STARLING_TMP_DIR}"
+        for (( idx=0; idx<NUM_VEH; idx++ )); do
+            CONFPATH="${STARLING_TMP_DIR}/vehicle${idx}.config"
+            touch "$CONFPATH"
+            # PX4_INSTANCE is required otherwise vehicles all default to zero
+            # PX4_SIM_HOST is for SITL connecting to gazebo instance on the control plane node
+            # PX4_SIM_INIT_LOC_X is to ensure multiple vehicles do not spawn on top of each other
+            # VEHILCE_FCU_URL is set as mavros only autogenerates if config is not provided. We provide config, so we must recreate the URL
+            { echo "PX4_INSTANCE=${idx}";
+            echo "PX4_SIM_HOST=${controlplanenode}";
+            echo "PX4_SIM_INIT_LOC_X=$((idx))";
+            echo "VEHICLE_FCU_URL=udp://127.0.0.1:$((14830+idx))@/";
+            echo "VEHICLE_FIRMWARE=px4";
+            echo "VEHICLE_MAVLINK_SYSID=$((idx+1))";
+            echo "VEHICLE_NAME=vehicle_${idx}";} > "$CONFPATH"
+            touch "${STARLING_TMP_DIR}/px4fmu_vehicle${idx}"
+        done
+
+        if [[ $NUM_UGV ]]; then
+            echo "Number of UGVs set to $NUM_UGV"
+            for (( idx=NUM_VEH; idx<NUM_VEH+NUM_UGV; idx++ )); do
+                CONFPATH="${STARLING_TMP_DIR}/vehicle${idx}.config"
+                touch "$CONFPATH"
+                # PX4_INSTANCE is required otherwise vehicles all default to zero
+                # PX4_SIM_HOST is for SITL connecting to gazebo instance on the control plane node
+                # PX4_SIM_INIT_LOC_X is to ensure multiple vehicles do not spawn on top of each other
+                # VEHILCE_FCU_URL is set as mavros only autogenerates if config is not provided. We provide config, so we must recreate the URL
+                { echo "PX4_INSTANCE=${idx}";
+                echo "PX4_SIM_HOST=${controlplanenode}";
+                echo "PX4_SIM_MODEL=r1-rover" # Add this one for rover
+                echo "PX4_SIM_INIT_LOC_X=$((idx))";
+                echo "VEHICLE_FCU_URL=udp://127.0.0.1:$((14830+idx))@/";
+                echo "VEHICLE_FIRMWARE=px4";
+                echo "VEHICLE_MAVLINK_SYSID=$((idx+1))";
+                echo "VEHICLE_NAME=vehicle_${idx}";} > "$CONFPATH"
+                touch "${STARLING_TMP_DIR}/px4fmu_vehicle${idx}"
+            done
+        fi
+
+        TOTAL_NUM_VEH=$((NUM_VEH+NUM_UGV))
+
+    else
+        echo "Vehicle config yaml specified at $VEHICLE_CONFIG_YAML"
+        TOTAL_NUM_VEH=$(yq ".vehicles | length" "$VEHICLE_CONFIG_YAML")
+        echo "Number of vehicles set to $TOTAL_NUM_VEH"
+
+        mkdir -p "${STARLING_TMP_DIR}"
+        for (( idx=0; idx<TOTAL_NUM_VEH; idx++ )); do
+            CONFPATH="${STARLING_TMP_DIR}/vehicle${idx}.config"
+            touch "$CONFPATH"
+            # PX4_INSTANCE is required otherwise vehicles all default to zero
+            # PX4_SIM_HOST is for SITL connecting to gazebo instance on the control plane node
+            # PX4_SIM_INIT_LOC_X is to ensure multiple vehicles do not spawn on top of each other
+            # VEHILCE_FCU_URL is set as mavros only autogenerates if config is not provided. We provide config, so we must recreate the URL
+            { echo "PX4_INSTANCE=${idx}";
+            echo "PX4_SIM_HOST=${controlplanenode}";
+            echo "VEHICLE_FCU_URL=udp://127.0.0.1:$((14830+idx))@/";
+            echo "VEHICLE_FIRMWARE=px4";
+            echo "VEHICLE_MAVLINK_SYSID=$((idx+1))";
+            echo "VEHICLE_NAME=vehicle_${idx}";} > "$CONFPATH"
+
+            VEHICLE_TYPE=$(yq ".vehicles[${idx}].type" "${VEHICLE_CONFIG_YAML}")
+            if [[ $VEHICLE_TYPE != "uav" ]]; then
+                echo "PX4_SIM_MODEL=${VEHICLE_TYPE}" >> "$CONFPATH"
+            fi
+
+            X_LOC=$(yq ".vehicles[${idx}].x" "${VEHICLE_CONFIG_YAML}")
+            if [[ "${X_LOC}" != "null" ]]; then
+                echo "PX4_SIM_INIT_LOC_X=$X_LOC" >> "$CONFPATH"
+            else
+                echo "PX4_SIM_INIT_LOC_X=$((idx))" >> "$CONFPATH"
+            fi
+
+            Y_LOC=$(yq ".vehicles[${idx}].y" "${VEHICLE_CONFIG_YAML}")
+            if [[ "${Y_LOC}" != "null" ]]; then
+                echo "PX4_SIM_INIT_LOC_Y=$Y_LOC" >> "$CONFPATH"
+            fi
+
+            Z_LOC=$(yq ".vehicles[${idx}].z" "${VEHICLE_CONFIG_YAML}")
+            if [[ "${Z_LOC}" != "null" ]]; then
+                echo "PX4_SIM_INIT_LOC_Z=$Z_LOC" >> "$CONFPATH"
+            fi
+
+            # Ensure this file exists
+            touch "${STARLING_TMP_DIR}/px4fmu_vehicle${idx}"
+        done
+
+    fi
 
     ## Write vehicle configurations and labels into kind config copy into tmp
     cp "${STARLING_CONFIG_DIR}/kind_config.yaml" "${STARLING_TMP_DIR}/kind_config.yaml"
-    for (( idx=0; idx<NUM_VEH; idx++ )); do
+    for (( idx=0; idx<TOTAL_NUM_VEH; idx++ )); do
 echo "
 - role: worker
   labels:

--- a/config/vehicle_marsupial_config.yaml
+++ b/config/vehicle_marsupial_config.yaml
@@ -1,0 +1,9 @@
+vehicles:
+  - type: uav
+    x: 0
+    y: 0
+    z: 2
+  - type: r1_rover
+    x: 0
+    y: 0
+    z: 0

--- a/docker-compose/ardupilot/docker-compose.ap-gazebo.windows.yml
+++ b/docker-compose/ardupilot/docker-compose.ap-gazebo.windows.yml
@@ -3,6 +3,8 @@ version: '3'
 services:
   simhost:
     image: uobflightlabstarling/starling-sim-iris-ap:latest
+    environment:
+      - AP_SITL_HOST=sitl
     ports:
       - "8080:8080"
 
@@ -10,16 +12,18 @@ services:
     image: uobflightlabstarling/starling-sim-ardupilot-copter:latest
     environment:
       - AP_USE_GAZEBO=true
+      - AP_SIM_HOST=simhost
     ports:
       - "18570:18570/udp"
-  
+
   mavros:
     image: uobflightlabstarling/starling-mavros:latest
     command: ros2 launch launch/mavros_bridge.launch.xml
     environment:
       - "MAVROS_TGT_FIRMWARE=apm"
       - "MAVROS_TGT_SYSTEM=1"
-      - "MAVROS_FCU_URL=tcp://127.0.0.1:5760"
+      - "MAVROS_FCU_URL=tcp://sitl:5760"
+      - "MAVROS_GCS_URL=tcp-l://:5761"
       - "MAVROS_CONFIG_PATH=/mavros_config_ap.yaml"
       - "MAVROS_PLUGINLISTS_PATH=/mavros_pluginlists_ap.yaml"
     ports:
@@ -29,4 +33,3 @@ services:
     image: uobflightlabstarling/rosbridge-suite:latest
     ports:
       - "9090:9090"
-


### PR DESCRIPTION
This PR does the following: 

- Allows the spawning of n_ugv (ground vehicles) in addition to uavs, defaults to 0 ugvs spawned. 
- Removes setting of number of vehicles (deprecated)
- Adds options to set the simulator and sitl kube configs (if changing the default sim environment - e.g. added or changed models) 
- Allows the swarm configuration to be set via a configuration yaml file at kind start time. Supported options are type, x, y, z. Must have root key of `vehicles` 
e.g.
```yaml
vehicles:
  - type: uav
    x: 0
    y: 0
    z: 2
  - type: platform_rover
    x: 0
    y: 0
    z: 0
```
- Also fixes ardupilot docker-compose launch. 